### PR TITLE
Update 1.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "poetry-core" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/poetry_core-{{ version }}.tar.gz
-  sha256: 514bd33c30e0bf56b0ed44ee15e120d7e47b61ad908b2b1011da68c48a84ada9
+  sha256: c6556c3b1ec5b8668e6ef5a4494726bc41d31907339425e194e78a6178436c14
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c6556c3b1ec5b8668e6ef5a4494726bc41d31907339425e194e78a6178436c14
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
   number: 0
   skip: True  # [py<37]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install --no-deps . -vv
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
[Upstream](https://github.com/python-poetry/poetry-core)
[Changelog](https://github.com/python-poetry/poetry-core/blob/main/CHANGELOG.md)

### Actions
- Update version number and sha256
- Add --no-deps to install script
- Update Python version skip to <38